### PR TITLE
Remove python and blank line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-python
 twitter==1.18.0
-


### PR DESCRIPTION
`pip` is refusing to setup the requirement as `python` is included.

```bash
$ pip install -r requirements.txt
Collecting python (from -r requirements.txt (line 1))
  Could not find a version that satisfies the requirement python (from -r requirements.txt (line 1)) (from versions: )
No matching distribution found for python (from -r requirements.txt (line 1))
```